### PR TITLE
Fix compatibility with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ if(NOT MSVC)
     if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         add_compile_options(-Werror)
     endif()
+else()
+    add_compile_options(/permissive-)
 endif()
 
 add_subdirectory(data)

--- a/external/mustache/include/kainjow/mustache.hpp
+++ b/external/mustache/include/kainjow/mustache.hpp
@@ -30,6 +30,7 @@
 #define KAINJOW_MUSTACHE_HPP
 
 #include <cassert>
+#include <cctype>
 #include <functional>
 #include <iostream>
 #include <memory>

--- a/src/pf.cpp
+++ b/src/pf.cpp
@@ -18,7 +18,7 @@ namespace {
 using string_flag = args::ValueFlag<std::string>;
 using path_flag   = args::ValueFlag<fs::path>;
 
-class eof : public std::exception {};
+class reached_eof : public std::exception {};
 
 std::string get_input_line() {
     std::cout.flush();
@@ -26,7 +26,7 @@ std::string get_input_line() {
     std::string ret;
     std::getline(std::cin, ret);
     if (std::cin.eof()) {
-        throw eof();
+        throw reached_eof();
     }
     return ret;
 }
@@ -322,7 +322,7 @@ int main(int argc, char** argv) {
             assert(false && "No subcommand selected?");
             std::terminate();
         }
-    } catch (const eof&) {
+    } catch (const reached_eof&) {
         return 2;
     }
 }

--- a/tests/compare_fs.cpp
+++ b/tests/compare_fs.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <fstream>
+#include <iterator>
 
 using namespace pf;
 using namespace pf::test;


### PR DESCRIPTION
Changes:

* Use `/permissive-` for MSVC
* Add missing `#include <cctype>` to mustache (https://github.com/kainjow/Mustache/issues/29)
* Add missing `#include <iterator>` to **tests/compare_fs.cpp**
* Changed `class eof` in pf.cpp to `class reached_eof`. MSVC complains that `eof` is ambiguous at `catch (const eof&)`