### PR TITLE
Fixed typo in 1.1.3 Example 2

### DIFF
--- a/data/spec.bs
+++ b/data/spec.bs
@@ -185,7 +185,7 @@ form a single *physical component*.
 namespace acme {
 
 // Forward-declare the private member data type
-namespace detail { class connection_ipml; }
+namespace detail { class connection_impl; }
 
 // The wrapper class
 class connection {


### PR DESCRIPTION
1.1.3. `Example 2` contains `connection.hpp` with typo `connection_ipml`.
`error: 'connection_impl' is not a member of 'acme::detail'`