### PR TITLE
fix extension name in settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "files.associations": {
         "*.lix": "elixir",
         "array": "cpp",


### PR DESCRIPTION
VS code extension settings. Old extension name was

`vector-of-bool.cmake-tools`

new one is 

`ms-vscode.cmake-tools`